### PR TITLE
Bump Windows runner to 2025, delete all version workarounds

### DIFF
--- a/.github/workflows/build-dxc.yaml
+++ b/.github/workflows/build-dxc.yaml
@@ -30,14 +30,11 @@ jobs:
           path: dxc/build/lib/libdxcompiler.so
   build-dxc-windows:
     # runs-on: windows-large-runner
-    runs-on: windows-2022
-    # According to https://learn.microsoft.com/en-us/windows/release-health/release-information
-    # 19045.6691 is the latest/last Windows 10 release, which we need to target in order
-    # to load dxcompiler.dll on our older GPU-runner CI machines.
+    runs-on: windows-2025
     steps:
       - uses: actions/checkout@v6
       - run: git clone https://github.com/microsoft/DirectXShaderCompiler.git dxc --revision=$(cat commit-hash) --recurse-submodules
-      - run: cmake -Bbuild -G "Visual Studio 17 2022" -C cmake/caches/PredefinedParams.cmake -DSPIRV_BUILD_TESTS=OFF -DLLVM_ENABLE_WERROR=OFF -DCMAKE_SYSTEM_VERSION="10.0.19045.6691"
+      - run: cmake -Bbuild -G "Visual Studio 17 2022" -C cmake/caches/PredefinedParams.cmake -DSPIRV_BUILD_TESTS=OFF -DLLVM_ENABLE_WERROR=OFF
         working-directory: dxc
       - run: cmake --build dxc/build --config Release -t dxcompiler
       - uses: actions/upload-artifact@v6
@@ -47,7 +44,7 @@ jobs:
 
       # Cross-compile to ARM64 with workaround from https://github.com/microsoft/DirectXShaderCompiler/issues/7000#issuecomment-2460490566 (also in hctbuild.cmd)
       - run: >
-          cmake -Bbuild-aarch64 -G "Visual Studio 17 2022" -C cmake/caches/PredefinedParams.cmake -DSPIRV_BUILD_TESTS=OFF -DLLVM_ENABLE_WERROR=OFF -DCMAKE_SYSTEM_VERSION="10.0.19045.6691"
+          cmake -Bbuild-aarch64 -G "Visual Studio 17 2022" -C cmake/caches/PredefinedParams.cmake -DSPIRV_BUILD_TESTS=OFF
           -DHLSL_INCLUDE_TESTS=OFF
           -DLLVM_INCLUDE_TESTS=OFF
           -DCLANG_INCLUDE_TESTS=OFF

--- a/.github/workflows/build-dxc.yaml
+++ b/.github/workflows/build-dxc.yaml
@@ -34,7 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git clone https://github.com/microsoft/DirectXShaderCompiler.git dxc --revision=$(cat commit-hash) --recurse-submodules
-      - run: cmake -Bbuild -G "Visual Studio 17 2022" -C cmake/caches/PredefinedParams.cmake -DSPIRV_BUILD_TESTS=OFF -DLLVM_ENABLE_WERROR=OFF
+      - run: >
+          cmake -Bbuild -G "Visual Studio 17 2022" -C cmake/caches/PredefinedParams.cmake -DSPIRV_BUILD_TESTS=OFF
+          -DLLVM_ENABLE_WERROR=OFF
+          -DHLSL_INCLUDE_TESTS=OFF
+          -DLLVM_INCLUDE_TESTS=OFF
+          -DCLANG_INCLUDE_TESTS=OFF
         working-directory: dxc
       - run: cmake --build dxc/build --config Release -t dxcompiler
       - uses: actions/upload-artifact@v6


### PR DESCRIPTION
Our CI is on the latest Windows version anyway, and the startup errors weren't due to any DLL incompatibility errors but a bug in the Visual C++ Runtime that we debugged **over two years ago** for a completely unrelated project:

https://stackoverflow.com/questions/78598141/first-stdmutexlock-crashes-in-application-built-with-latest-visual-studio

In short libraries like DXC, but also updated drivers and even the Vulkan SDK VVL compile with a newer initializer (and without defining `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR`) which leads to our process crashing in `MSVCP140!mtx_do_lock` at startup whenever they load any of these libraries.  The simple solution is to update or reinstall the Visual C++ Redistributable:

https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-supported-redistributable-version

(Back than it seemed that a hotpatch was released without bumping version numbers, making some machines crash on `14.40.33810` while others did not - reinstalling the same version fixed it too...)